### PR TITLE
Add api to allow deletion of items older than a provided timestamp

### DIFF
--- a/db/cassandra/queries.js
+++ b/db/cassandra/queries.js
@@ -170,8 +170,9 @@ queries.removeLike = 'DELETE FROM {KEYSPACE}.likes WHERE user = ? AND item = ?';
  *    DELETE FROM {KEYSPACE}.userline WHERE user = ? AND item = ?
  */
 queries.upsertUserTimeline = 'INSERT INTO {KEYSPACE}.{TIMELINE} (user, item, type, time, visibility, from_follow) VALUES(?, ?, ?, ?, ?, ?);';
-queries.selectTimeline = 'SELECT user, time, dateOf(time) AS date, item, type, visibility, from_follow FROM {KEYSPACE}.{TIMELINE} WHERE user = ? {TYPEQUERY}';
+queries.selectTimeline = 'SELECT user, time, dateOf(time) AS date, item, type, visibility, from_follow FROM {KEYSPACE}.{TIMELINE} WHERE user = ? {TYPEQUERY} {OLDERTHANQUERY}';
 queries.removeFromTimeline = 'DELETE FROM {KEYSPACE}.{TIMELINE} WHERE user = ? AND time = ?';
 queries.selectAllItems = 'SELECT user, time FROM {KEYSPACE}.{TIMELINE} WHERE item = ?';
 queries.selectAllFollowItems = 'SELECT user, time FROM {KEYSPACE}.{TIMELINE} WHERE from_follow = ?';
 queries.typeQuery = 'AND type = ?';
+queries.olderThanQuery = 'AND time <= ?';

--- a/db/postgres/queries.js
+++ b/db/postgres/queries.js
@@ -137,7 +137,7 @@ queries.selectTimeline = 'SELECT tl."user", tl.time, tl.time as date, tl.item, t
                          'LEFT OUTER JOIN {KEYSPACE}.likes l ON (tl.item = l.like and tl.type = \'like\') ' +
                          'LEFT OUTER JOIN {KEYSPACE}.friends f ON (tl.item = f.friend and tl.type = \'friend\') ' +
                          'LEFT OUTER JOIN {KEYSPACE}.followers fl ON (tl.item = fl.follow and tl.type = \'follow\') ' +
-                         'WHERE tl."user" = $1{TYPEQUERY}' +
+                         'WHERE tl."user" = $1{TYPEQUERY}{OLDERTHANQUERY}' +
                          'ORDER BY time DESC';
 
 queries.upsertUserTimeline = 'INSERT INTO {KEYSPACE}.{TIMELINE} ("user", item, type, time, visibility, from_follow) VALUES($1, $2, $3, $4, $5, $6);';
@@ -145,5 +145,6 @@ queries.removeFromTimeline = 'DELETE FROM {KEYSPACE}.{TIMELINE} WHERE "user" = $
 queries.selectAllItems = 'SELECT "user", time FROM {KEYSPACE}.{TIMELINE} WHERE item = $1';
 queries.selectAllFollowItems = 'SELECT "user", time FROM {KEYSPACE}.{TIMELINE} WHERE from_follow = $1';
 queries.typeQuery = ' AND tl.type = $2';
+queries.olderThanQuery = ' AND tl.time <= $2';
 
 module.exports = q;

--- a/tests/acceptance/api/feeds.test.js
+++ b/tests/acceptance/api/feeds.test.js
@@ -419,6 +419,21 @@ databases.forEach(function (db) {
           });
         });
       });
+
+      it('can remove feed items older than a specific time', function (done) {
+        api.feed.getFeed(keyspace, users['cliftonc'].user, users['cliftonc'].user, function (err, feed) {
+          expect(err).to.be(null);
+          var feedLength = feed.length;
+          api.feed.removeFeedsOlderThan(keyspace, users['cliftonc'].user, new Date(2015, 10, 1), function (err) {
+            expect(err).to.be(null);
+            api.feed.getFeed(keyspace, users['cliftonc'].user, users['cliftonc'].user, function (err, feed) {
+              expect(err).to.be(null);
+              expect(feed.length).to.be(feedLength - 1);
+              done();
+            });
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
To allow newsfeed cleanup, e.g. on a scheduled basis select users and remove feed items > 30 days old.