### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/db/postgres/index.js
+++ b/db/postgres/index.js
@@ -1,5 +1,5 @@
 var pg = require('pg');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var path = require('path');
 var debug = require('debug')('seguir:postgres');
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
     "moment": "^2.12.0",
-    "node-uuid": "^1.4.7",
     "pg": "^4.5.2",
     "pg-query-stream": "^1.0.0",
     "redis": "^2.6.0-0",
@@ -42,7 +41,8 @@
     "rsmq": "^0.7.1",
     "rsmq-worker": "^0.5.0",
     "sanitize-html": "^1.11.4",
-    "string-template": "^1.0.0"
+    "string-template": "^1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "apidoc": "^0.15.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.