### PR TITLE
addPost take extra argument 'propagateTo' to propagate to someone other than followers

### DIFF
--- a/api/feed/index.js
+++ b/api/feed/index.js
@@ -31,7 +31,7 @@ module.exports = (api) => {
     const nextIfFinished = (doNotIncrement, cb) => {
       if (!doNotIncrement) { finished++; }
       if (read === finished && done) {
-        async.each(jobData.propagateTo, ({ user }, cb) => {
+        async.each(jobData.propagateTo, (user, cb) => {
           upsertTimeline(jobData.keyspace, 'feed_timeline', user, jobData.id, jobData.type, jobData.timestamp, jobData.visibility, null, () => cb());
         }, next);
       } else {
@@ -63,7 +63,7 @@ module.exports = (api) => {
           }
           if (!isPrivate || (isPrivate && isFriend)) {
             upsertTimeline(jobData.keyspace, 'feed_timeline', row.user_follower, jobData.id, jobData.type, jobData.timestamp, jobData.visibility, row.follow, (err) => {
-              if (!err) { jobData.propagateTo = jobData.propagateTo.filter(({ user }) => !user.equals(row.user_follower)); }
+              if (!err) { jobData.propagateTo = jobData.propagateTo.filter((user) => !user.equals(row.user_follower)); }
               nextIfFinished(false, cb);
             });
           } else {


### PR DESCRIPTION
This additional complexity tag onto insertFollowersTimeline to propagate to additional people's feed_timeline (e.g. resource review post to appear in author's timeline)

thing to note is that current insertFollowersTimeline doesn't fail early the whole process when any of the individual upsertTimeline fails for each follower, thus the additional propagation logic also ignores failure.

propagateTo is expected to be [user(uuid)...] filled in from electric-seguir based on the content.category and content.type of the post for the time being