### PR TITLE
when a propagation of a post is based on a single interest

### DIFF
--- a/tests/acceptance/api/posts.test.js
+++ b/tests/acceptance/api/posts.test.js
@@ -265,6 +265,26 @@ databases.forEach((db) => {
           });
         });
       });
+
+      it('can post message to interested users feed by paging', (done) => {
+        const australia = { type: 'country', keyword: 'australia' };
+        const filterPost = (feed, id) => feed.filter(({ type }) => type === 'post').map(({ post }) => post.toString()).filter((postId) => postId === id);
+        api.interest.upsertInterests(keyspace, users['cliftonc'].user, [australia], (err) => {
+          expect(err).to.be(null);
+          api.post.addPostToInterestedUsers(keyspace, users['json'].user, { hello: 'This is australian...' }, [australia], 'application/json', api.client.getTimestamp(), api.visibility.PUBLIC, 'P-1234', (err, post) => {
+            expect(err).to.be(null);
+            api.feed.getFeed(keyspace, users['cliftonc'].user, users['cliftonc'].user, (err, feed) => {
+              expect(err).to.be(null);
+              expect(filterPost(feed, post.post.toString())).to.have.length(1);
+              api.feed.getFeed(keyspace, users['ted'].user, users['ted'].user, (err, feed) => {
+                expect(err).to.be(null);
+                expect(filterPost(feed, post.post.toString())).to.have.length(0);
+                done();
+              });
+            });
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
we don't need to load every users up to uniquify them, instead use pagination to process per page of users

as a side note;

I feel like we need simpler and unified interface in seguir that deals with 'propagation' of a 'post' that takes a (broadcast uuid, post id, collection of target audience) 

Benefit of such interface is that it would hide the complexity of having to know full collection of target audience before a broadcast happens (as we do in propagation via multiple interests) as it would take care of potential duplicate target audience for a given broadcast uuid

It would also allow us to separate the concern of working out the target audience of a post and actual delivery of such broadcast.